### PR TITLE
Add binutils to Ubuntu smoketest dependencies to fix 14.04 clang builds

### DIFF
--- a/.github/workflows/push-smoketest-ubuntu.yml
+++ b/.github/workflows/push-smoketest-ubuntu.yml
@@ -32,7 +32,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           apt-get update -qq
-          apt-get install -qq make ${{ matrix.compiler }}
+          apt-get install -qq make binutils ${{ matrix.compiler }}
 
       - name: Make
         env:


### PR DESCRIPTION
Seems the builds started to rely on the presence of `/usr/bin/ld` and on `ubuntu:14.04` clang does not pull that in. Added `binutils` as an explicit dependency.