### PR TITLE
Add compat-gcc-44 to Centos 7 build dependencies

### DIFF
--- a/.github/workflows/push-smoketest-centos.yml
+++ b/.github/workflows/push-smoketest-centos.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Install Dependencies
         run: yum install -y make glibc-devel ${{ matrix.compiler }}
 
+      - name: Install Centos 7 LLVM/Clang Dependencies
+        if: ${{ matrix.image == 'centos:7' && matrix.compiler == 'clang' }}
+        run: yum install -y compat-gcc-44
+
       - name: Make
         env:
           CC: ${{ matrix.compiler }}


### PR DESCRIPTION
The CentOS LLVM/Clang builds have implicitly started to rely on the presence of `crtbegin.o`. On CentOS 7, this is provided by the GCC 4.4 compatibility package for installations without GCC. This package has been added as a dependency of CentOS 7 LLVM/Clang builds.