### PR TITLE
Add a Github Action to run LLVM scan-build on every push

### DIFF
--- a/.github/workflows/push-scan-build.yml
+++ b/.github/workflows/push-scan-build.yml
@@ -1,0 +1,30 @@
+name: LLVM scan-build
+on: push
+
+jobs:
+  llvm-scan-build:
+    runs-on: ubuntu-20.04
+
+    container:
+      image: debian:bullseye
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update -qq
+          apt-get install -qq make gcc clang-tools libfindbin-libs-perl
+
+      - name: LLVM scan-build
+        run:  scan-build --status-bugs -o results/ make
+
+      - name: Publish LLVM scan-build results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: llvm-scan-build-results
+          path: results/


### PR DESCRIPTION
I've added a currently red build for potentially adding LLVM `scan-build` as a quality gate to the repository.

This PR has been created as a draft PR as I don't like merging red builds. We don't currently have branch protection rules or quality gate enforcements in place, but on general principles.